### PR TITLE
New point system v2

### DIFF
--- a/JigsawBot/Constants.cs
+++ b/JigsawBot/Constants.cs
@@ -3,6 +3,7 @@
     public static class Constants
     {
         public const int PUZZLE_STARTING_POINTS = 1080;
+        public const int PUZZLE_MINIMUM_POINTS  = 120;
 
         public const int BACKUP_TIMER = 12 * 60 * 60 * 1000;
 

--- a/JigsawBot/Modules/BotActions.cs
+++ b/JigsawBot/Modules/BotActions.cs
@@ -121,7 +121,7 @@ namespace JigsawBot
                 var newPuzzle = new PuzzleModel
                 {
                     Code   = puzzle.PuzzleCode,
-                    Points = Constants.PUZZLE_STARTING_POINTS
+                    Points = CalculatePuzzlePoints(0)
                 };
                 _data.AddOrUpdatePuzzle(newPuzzle);
 

--- a/JigsawBot/Modules/BotActions.cs
+++ b/JigsawBot/Modules/BotActions.cs
@@ -283,10 +283,10 @@ namespace JigsawBot
         {
             if (solvedBy == 0)
             {
-                return Constants.PUZZLE_STARTING_POINTS;
+                return Constants.PUZZLE_MINIMUM_POINTS + Constants.PUZZLE_STARTING_POINTS;
             }
 
-            return Constants.PUZZLE_STARTING_POINTS / solvedBy;
+            return Constants.PUZZLE_MINIMUM_POINTS + Constants.PUZZLE_STARTING_POINTS / solvedBy;
         }
 
         #region Private

--- a/JigsawBot/Modules/BotActions.cs
+++ b/JigsawBot/Modules/BotActions.cs
@@ -152,7 +152,7 @@ namespace JigsawBot
 
             await UpdateRoleAsync(user, dbUser.Score, oldScore);
 
-            if (puzzle.Points != 1)
+            if (puzzle.Points > Constants.PUZZLE_MINIMUM_POINTS)
             {
                 var usersWhoSolvedPuzzle = _data.GetUsersWhoCompletedPuzzle(code);
 


### PR DESCRIPTION
Improves #2 
Still doesn't satisfy me so I will keep the issue open

- Each puzzle starts at 1200 points
- A puzzle's points are divided among all the players who solved it with the fomula: `120 + 1080 / solves`
- Each time a puzzle is solved, the score is updated for every player who solved that puzzle
- A puzzle's score cannot go below 1